### PR TITLE
Enable Smart Placement in wrangler.jsonc

### DIFF
--- a/tests/unit/EmailComposer.test.ts
+++ b/tests/unit/EmailComposer.test.ts
@@ -1,4 +1,3 @@
-
 import { describe, expect, it } from "vitest";
 import { EmailComposer } from "../../src/email/components/EmailComposer";
 import { createMockParsedEmail } from "../mocks/email";
@@ -55,13 +54,13 @@ describe("EmailComposer", () => {
     });
 
     it("should handle missing body gracefully", () => {
-        const originalMessage = createMockParsedEmail({
-            body: ""
-        });
-        const formatted = composer.formatQuotedContent(originalMessage);
+      const originalMessage = createMockParsedEmail({
+        body: "",
+      });
+      const formatted = composer.formatQuotedContent(originalMessage);
 
-        expect(formatted).toContain("From: ");
-        expect(formatted).not.toContain("Original message body.");
+      expect(formatted).toContain("From: ");
+      expect(formatted).not.toContain("Original message body.");
     });
   });
 });

--- a/tests/unit/HtmlEmailComposer.test.ts
+++ b/tests/unit/HtmlEmailComposer.test.ts
@@ -1,4 +1,3 @@
-
 import { describe, expect, it } from "vitest";
 import { HtmlEmailComposer } from "../../src/email/components/HtmlEmailComposer";
 import { createMockParsedEmail } from "../mocks/email";
@@ -48,8 +47,7 @@ describe("HtmlEmailComposer", () => {
         from: "sender@example.com",
       });
 
-      const replyContent =
-        "<div class=MsoNormal><p>Line 1.</p><p>Line 2.</p></div>";
+      const replyContent = "<div class=MsoNormal><p>Line 1.</p><p>Line 2.</p></div>";
       const html = composer.composeHtmlReply(originalEmail, replyContent);
 
       expect(html).toContain(replyContent);
@@ -68,12 +66,12 @@ describe("HtmlEmailComposer", () => {
     });
 
     it("should include CC in headers if present", () => {
-        const originalEmail = createMockParsedEmail({
-            cc: ["cc1@example.com", "cc2@example.com"]
-        });
+      const originalEmail = createMockParsedEmail({
+        cc: ["cc1@example.com", "cc2@example.com"],
+      });
 
-        const html = composer.composeHtmlReply(originalEmail, "Reply");
-        expect(html).toContain("Cc:</b> cc1@example.com; cc2@example.com");
+      const html = composer.composeHtmlReply(originalEmail, "Reply");
+      expect(html).toContain("Cc:</b> cc1@example.com; cc2@example.com");
     });
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,6 +14,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-10-31",
   "compatibility_flags": ["nodejs_compat"],
+  "placement": {
+    "mode": "smart"
+  },
   "assets": {
     "binding": "ASSETS",
     "directory": "./public",


### PR DESCRIPTION
Enable Smart Placement for the Cloudflare Worker.

This change modifies `wrangler.jsonc` to set the placement mode to "smart". It also includes updates to generated types and minor formatting fixes in test files resulting from running `npm run lint:fix`.

---
*PR created automatically by Jules for task [1641917229129115372](https://jules.google.com/task/1641917229129115372) started by @taoi11*