### PR TITLE
Fix logs not surfacing in CF Workers observability tab

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -16,6 +16,7 @@ interface LogContext {
 }
 
 // Simple logger using native console - Workers handles timestamps and structured logging
+// All output is JSON.stringify'd so CF Workers observability can parse and index fields
 export class Logger {
   private static instance: Logger;
 
@@ -30,25 +31,29 @@ export class Logger {
     return Logger.instance;
   }
 
+  private emit(method: "log" | "warn" | "error" | "debug", data: Record<string, unknown>): void {
+    console[method](JSON.stringify(data));
+  }
+
   info(message: string, context?: LogContext): void {
-    console.log({ message, level: "info", ...context });
+    this.emit("log", { message, level: "info", ...context });
   }
 
   warn(message: string, context?: LogContext): void {
-    console.warn({ message, level: "warn", ...context });
+    this.emit("warn", { message, level: "warn", ...context });
   }
 
   error(message: string, context?: LogContext): void {
-    console.error({ message, level: "error", ...context });
+    this.emit("error", { message, level: "error", ...context });
   }
 
   debug(message: string, context?: LogContext): void {
-    console.debug({ message, level: "debug", ...context });
+    this.emit("debug", { message, level: "debug", ...context });
   }
 
   performance(operation: string, startTime: number, context?: LogContext): void {
     const processingTime = Date.now() - startTime;
-    console.log({
+    this.emit("log", {
       message: `Performance: ${operation} completed in ${processingTime}ms`,
       level: "info",
       ...context,


### PR DESCRIPTION
## Summary
- Logger was passing plain JS objects to `console.log()`, which serialized as `[object Object]` in CF Workers observability
- Added `JSON.stringify()` via a private `emit()` helper that all log methods route through
- Logs now appear as parseable structured JSON with queryable `message`, `level`, and context fields

## Test plan
- [x] `npm run compile` — type-check passes
- [x] `npm run test` — all 194 tests pass
- [x] `npm run lint` — Logger.ts passes lint
- [ ] After deploy: verify logs appear as structured JSON in CF Workers observability tab

https://claude.ai/code/session_01DVe9jqiUMawexeF1TpDz6z