### PR TITLE
⚡ Bolt: [performance improvement] Cache R2 document retrieval in memory

### DIFF
--- a/src/storage/DocumentRetriever.ts
+++ b/src/storage/DocumentRetriever.ts
@@ -11,12 +11,29 @@
 import { StorageConnectionError, StorageNotFoundError, StorageValidationError } from "../errors";
 import { formatError, Logger } from "../Logger";
 
+interface CacheEntry {
+  content: string;
+  timestamp: number;
+}
+
 // Retrieve documents from R2 bucket
 export class DocumentRetriever {
   private logger: Logger;
+  // ⚡ Bolt: In-memory cache for R2 documents to reduce I/O wait times
+  // and R2 billing costs across multiple executions in the same worker isolate
+  private static cache: Map<string, CacheEntry> = new Map();
+  // Cache TTL: 1 hour (3600000 ms)
+  private static readonly CACHE_TTL_MS = 3600000;
+  // Max cache size to prevent memory leaks
+  private static readonly MAX_CACHE_SIZE = 50;
 
   constructor(private r2Bucket: R2Bucket) {
     this.logger = Logger.getInstance();
+  }
+
+  // Clear the static cache (used primarily for testing)
+  static clearCache(): void {
+    DocumentRetriever.cache.clear();
   }
 
   // Get document content from R2 storage
@@ -32,11 +49,24 @@ export class DocumentRetriever {
         throw new StorageValidationError("Invalid agent name or filename provided");
       }
 
+      const key = `${agentName}/${filename}`;
+      const now = Date.now();
+
+      // ⚡ Bolt: Check the in-memory cache first with TTL
+      const cached = DocumentRetriever.cache.get(key);
+      if (cached && now - cached.timestamp < DocumentRetriever.CACHE_TTL_MS) {
+        this.logger.info("Document retrieved from cache", { key });
+
+        // Update insertion order for LRU behavior
+        DocumentRetriever.cache.delete(key);
+        DocumentRetriever.cache.set(key, cached);
+
+        return cached.content;
+      }
+
       if (!this.r2Bucket) {
         throw new StorageConnectionError("R2 bucket not available");
       }
-
-      const key = `${agentName}/${filename}`;
 
       const object = await this.r2Bucket.get(key);
 
@@ -56,6 +86,15 @@ export class DocumentRetriever {
         key,
         size: content.length,
       });
+
+      // ⚡ Bolt: Cache the retrieved content for future requests, with eviction if needed
+      if (DocumentRetriever.cache.size >= DocumentRetriever.MAX_CACHE_SIZE) {
+        // Evict oldest entry (Map iterates in insertion order)
+        const firstKey = DocumentRetriever.cache.keys().next().value;
+        if (firstKey) DocumentRetriever.cache.delete(firstKey);
+      }
+      DocumentRetriever.cache.set(key, { content, timestamp: now });
+
       return content;
     } catch (error) {
       // Re-throw typed errors

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,13 @@
  * - Sets up global test configuration
  */
 
-import { vi } from "vitest";
+// Clear the DocumentRetriever cache before each test
+import { beforeEach, vi } from "vitest";
+import { DocumentRetriever } from "../src/storage/DocumentRetriever";
+
+beforeEach(() => {
+  DocumentRetriever.clearCache();
+});
 
 // Mock the cloudflare:email module (not available in test environment)
 vi.mock("cloudflare:email", () => ({


### PR DESCRIPTION
💡 What: Implemented a static in-memory LRU cache in `DocumentRetriever` for R2 documents, with a size limit of 50 and a 1-hour TTL. Test setup was also updated to clear this static cache before each test run.
🎯 Why: In Cloudflare Workers, retrieving documents from an R2 bucket requires network I/O which adds latency and billing cost (Class B operations). Because the same documents (like policies and prompts) are repeatedly fetched by sub-agents across different requests, caching them in the worker isolate's global memory prevents redundant operations.
📊 Impact: Eliminates R2 fetching latency (typically 50-100ms) and Class B operation costs for frequently requested documents.
🔬 Measurement: Run the application and observe the logs. The first request will log "Retrieving document" and subsequent requests for the same document within an hour will log "Document retrieved from cache", demonstrating the avoided R2 fetch. Memory bounds protect against OOM crashes.

---
*PR created automatically by Jules for task [8433669218598030130](https://jules.google.com/task/8433669218598030130) started by @taoi11*