### PR TITLE
⚡ Bolt: Cache R2 documents to reduce redundant network calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-08 - Unbounded cache risk in Cloudflare Workers
+**Learning:** Implementing unbounded static caching for DocumentRetriever in a worker isolate can lead to Out-Of-Memory (OOM) crashes and stale data across multiple requests over time.
+**Action:** Always implement a max size limit and TTL for static caches in Cloudflare Workers to manage memory effectively and prevent serving stale documents.

--- a/src/storage/DocumentRetriever.ts
+++ b/src/storage/DocumentRetriever.ts
@@ -89,19 +89,20 @@ export class DocumentRetriever {
         throw new StorageNotFoundError(`Document is empty: ${key}`);
       }
 
-      // ⚡ Bolt: Store fetched document in static cache with size limit to prevent memory leaks
-      if (DocumentRetriever.documentCache.size >= DocumentRetriever.MAX_CACHE_SIZE) {
-        // Simple eviction: remove the oldest inserted entry
-        const oldestKey = DocumentRetriever.documentCache.keys().next().value;
-        if (oldestKey !== undefined) {
-          DocumentRetriever.documentCache.delete(oldestKey);
-        }
-      }
-
+      // ⚡ Bolt: Store fetched document in static cache.
       DocumentRetriever.documentCache.set(key, {
         content,
         expiresAt: Date.now() + DocumentRetriever.CACHE_TTL_MS,
       });
+
+      // Keep cache strictly bounded even when concurrent requests insert around the same time.
+      while (DocumentRetriever.documentCache.size > DocumentRetriever.MAX_CACHE_SIZE) {
+        const oldestKey = DocumentRetriever.documentCache.keys().next().value;
+        if (oldestKey === undefined) {
+          break;
+        }
+        DocumentRetriever.documentCache.delete(oldestKey);
+      }
 
       this.logger.info("Document retrieved successfully", {
         key,

--- a/src/storage/DocumentRetriever.ts
+++ b/src/storage/DocumentRetriever.ts
@@ -12,7 +12,24 @@ import { StorageConnectionError, StorageNotFoundError, StorageValidationError } 
 import { formatError, Logger } from "../Logger";
 
 // Retrieve documents from R2 bucket
+interface CacheEntry {
+  content: string;
+  expiresAt: number;
+}
+
 export class DocumentRetriever {
+  // ⚡ Bolt: Cache R2 documents using a static property so that instances
+  // sharing the same isolate (subsequent/concurrent fetch requests)
+  // can reuse already retrieved documents instead of hitting R2.
+  private static documentCache = new Map<string, CacheEntry>();
+  private static readonly MAX_CACHE_SIZE = 50; // Limit size to prevent memory leaks (OOM)
+  private static readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes TTL to prevent serving stale data
+
+  /** ⚡ Bolt: Expose a way to clear the cache, primarily for testing purposes */
+  public static clearCache(): void {
+    DocumentRetriever.documentCache.clear();
+  }
+
   private logger: Logger;
 
   constructor(private r2Bucket: R2Bucket) {
@@ -38,6 +55,18 @@ export class DocumentRetriever {
 
       const key = `${agentName}/${filename}`;
 
+      // ⚡ Bolt: Return cached content if available and not expired to avoid unnecessary R2 reads
+      if (DocumentRetriever.documentCache.has(key)) {
+        // biome-ignore lint/style/noNonNullAssertion: Cache key is verified to exist via .has()
+        const entry = DocumentRetriever.documentCache.get(key)!;
+        if (Date.now() < entry.expiresAt) {
+          this.logger.info("Document retrieved from cache", { key });
+          return entry.content;
+        }
+        // Cache expired, remove it
+        DocumentRetriever.documentCache.delete(key);
+      }
+
       const object = await this.r2Bucket.get(key);
 
       if (!object) {
@@ -51,6 +80,20 @@ export class DocumentRetriever {
         this.logger.warn("Document is empty", { key });
         throw new StorageNotFoundError(`Document is empty: ${key}`);
       }
+
+      // ⚡ Bolt: Store fetched document in static cache with size limit to prevent memory leaks
+      if (DocumentRetriever.documentCache.size >= DocumentRetriever.MAX_CACHE_SIZE) {
+        // Simple eviction: remove the oldest inserted entry
+        const oldestKey = DocumentRetriever.documentCache.keys().next().value;
+        if (oldestKey !== undefined) {
+          DocumentRetriever.documentCache.delete(oldestKey);
+        }
+      }
+
+      DocumentRetriever.documentCache.set(key, {
+        content,
+        expiresAt: Date.now() + DocumentRetriever.CACHE_TTL_MS,
+      });
 
       this.logger.info("Document retrieved successfully", {
         key,

--- a/src/storage/DocumentRetriever.ts
+++ b/src/storage/DocumentRetriever.ts
@@ -4,8 +4,10 @@
  * Document retriever for R2 storage
  *
  * Top-level declarations:
- * - DocumentRetriever (line 15): Retrieve documents from R2 bucket
- * - getDocument (line 21): Get document content from R2 storage
+ * - CacheEntry (line 17): Cached document content and expiration metadata
+ * - DocumentRetriever (line 22): Retrieve documents from R2 bucket
+ * - clearCache (line 34): Clear static document cache for tests
+ * - getDocument (line 45): Get document content from R2 storage
  */
 
 import { StorageConnectionError, StorageNotFoundError, StorageValidationError } from "../errors";
@@ -21,8 +23,11 @@ export class DocumentRetriever {
   // ⚡ Bolt: Cache R2 documents using a static property so that instances
   // sharing the same isolate (subsequent/concurrent fetch requests)
   // can reuse already retrieved documents instead of hitting R2.
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Used by static/instance methods; Biome does not reliably track private static class references.
   private static documentCache = new Map<string, CacheEntry>();
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Used by getDocument() cache eviction logic.
   private static readonly MAX_CACHE_SIZE = 50; // Limit size to prevent memory leaks (OOM)
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Used by getDocument() cache expiration logic.
   private static readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes TTL to prevent serving stale data
 
   /** ⚡ Bolt: Expose a way to clear the cache, primarily for testing purposes */
@@ -60,6 +65,9 @@ export class DocumentRetriever {
         // biome-ignore lint/style/noNonNullAssertion: Cache key is verified to exist via .has()
         const entry = DocumentRetriever.documentCache.get(key)!;
         if (Date.now() < entry.expiresAt) {
+          // Refresh insertion order on hit so eviction is LRU-like rather than FIFO.
+          DocumentRetriever.documentCache.delete(key);
+          DocumentRetriever.documentCache.set(key, entry);
           this.logger.info("Document retrieved from cache", { key });
           return entry.content;
         }

--- a/src/storage/DocumentRetriever.ts
+++ b/src/storage/DocumentRetriever.ts
@@ -68,7 +68,7 @@ export class DocumentRetriever {
           // Refresh insertion order on hit so eviction is LRU-like rather than FIFO.
           DocumentRetriever.documentCache.delete(key);
           DocumentRetriever.documentCache.set(key, entry);
-          this.logger.info("Document retrieved from cache", { key });
+          this.logger.debug("Document retrieved from cache", { key });
           return entry.content;
         }
         // Cache expired, remove it

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,13 @@
  * - Sets up global test configuration
  */
 
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+import { DocumentRetriever } from "../src/storage/DocumentRetriever";
+
+// ⚡ Bolt: Clear DocumentRetriever cache before each test to prevent test cross-contamination
+beforeEach(() => {
+  DocumentRetriever.clearCache();
+});
 
 // Mock the cloudflare:email module (not available in test environment)
 vi.mock("cloudflare:email", () => ({

--- a/tests/unit/DocumentRetriever.test.ts
+++ b/tests/unit/DocumentRetriever.test.ts
@@ -1,0 +1,89 @@
+/**
+ * tests/unit/DocumentRetriever.test.ts
+ *
+ * Unit tests for R2 document retrieval and static cache behavior
+ *
+ * Tests:
+ * - Reuses cached documents within TTL
+ * - Refetches documents after TTL expiry
+ * - Evicts least-recently-used documents when cache reaches capacity
+ * - clearCache removes cached documents
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { DocumentRetriever } from "../../src/storage/DocumentRetriever";
+
+const createR2Bucket = () => {
+  const get = vi.fn(async (key: string) => ({
+    text: vi.fn(async () => `content:${key}`),
+  }));
+
+  return {
+    bucket: { get } as unknown as R2Bucket,
+    get,
+  };
+};
+
+describe("DocumentRetriever", () => {
+  it("should reuse cached documents within the TTL", async () => {
+    const { bucket, get } = createR2Bucket();
+    const retriever = new DocumentRetriever(bucket);
+
+    const first = await retriever.getDocument("leave", "policy.md");
+    const second = await retriever.getDocument("leave", "policy.md");
+
+    expect(first).toBe("content:leave/policy.md");
+    expect(second).toBe("content:leave/policy.md");
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith("leave/policy.md");
+  });
+
+  it("should refetch documents after the TTL expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    try {
+      const { bucket, get } = createR2Bucket();
+      const retriever = new DocumentRetriever(bucket);
+
+      await retriever.getDocument("leave", "policy.md");
+      vi.setSystemTime(new Date("2026-01-01T00:04:59Z"));
+      await retriever.getDocument("leave", "policy.md");
+      vi.setSystemTime(new Date("2026-01-01T00:05:01Z"));
+      await retriever.getDocument("leave", "policy.md");
+
+      expect(get).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should evict the least-recently-used document when the cache reaches capacity", async () => {
+    const { bucket, get } = createR2Bucket();
+    const retriever = new DocumentRetriever(bucket);
+
+    for (let index = 0; index < 50; index += 1) {
+      await retriever.getDocument("leave", `policy-${index}.md`);
+    }
+
+    await retriever.getDocument("leave", "policy-0.md");
+    await retriever.getDocument("leave", "policy-50.md");
+    await retriever.getDocument("leave", "policy-0.md");
+    await retriever.getDocument("leave", "policy-1.md");
+
+    expect(get).toHaveBeenCalledTimes(52);
+    expect(get).toHaveBeenNthCalledWith(51, "leave/policy-50.md");
+    expect(get).toHaveBeenNthCalledWith(52, "leave/policy-1.md");
+  });
+
+  it("should clear cached documents", async () => {
+    const { bucket, get } = createR2Bucket();
+    const retriever = new DocumentRetriever(bucket);
+
+    await retriever.getDocument("leave", "policy.md");
+    DocumentRetriever.clearCache();
+    await retriever.getDocument("leave", "policy.md");
+
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
💡 What: Implemented a static LRU-like cache in `DocumentRetriever` with a 50-item limit and 5-minute TTL.
🎯 Why: Instances of the same Cloudflare Worker isolate were needlessly re-fetching identical policy documents from R2 across multiple requests, increasing latency and network I/O.
📊 Impact: Expected to significantly reduce R2 read operations and decrease average response time for multi-query tools by serving common policies instantly from memory.
🔬 Measurement: Compare worker duration metrics and R2 Class B operation counts before and after deployment for identical requests.

---
*PR created automatically by Jules for task [8735988862346189082](https://jules.google.com/task/8735988862346189082) started by @taoi11*