### PR TITLE
Prevent cache overshoot in DocumentRetriever by enforcing bounded eviction

### DIFF
--- a/src/storage/DocumentRetriever.ts
+++ b/src/storage/DocumentRetriever.ts
@@ -89,19 +89,20 @@ export class DocumentRetriever {
         throw new StorageNotFoundError(`Document is empty: ${key}`);
       }
 
-      // ⚡ Bolt: Store fetched document in static cache with size limit to prevent memory leaks
-      if (DocumentRetriever.documentCache.size >= DocumentRetriever.MAX_CACHE_SIZE) {
-        // Simple eviction: remove the oldest inserted entry
-        const oldestKey = DocumentRetriever.documentCache.keys().next().value;
-        if (oldestKey !== undefined) {
-          DocumentRetriever.documentCache.delete(oldestKey);
-        }
-      }
-
+      // ⚡ Bolt: Store fetched document in static cache.
       DocumentRetriever.documentCache.set(key, {
         content,
         expiresAt: Date.now() + DocumentRetriever.CACHE_TTL_MS,
       });
+
+      // Keep cache strictly bounded even when concurrent requests insert around the same time.
+      while (DocumentRetriever.documentCache.size > DocumentRetriever.MAX_CACHE_SIZE) {
+        const oldestKey = DocumentRetriever.documentCache.keys().next().value;
+        if (oldestKey === undefined) {
+          break;
+        }
+        DocumentRetriever.documentCache.delete(oldestKey);
+      }
 
       this.logger.info("Document retrieved successfully", {
         key,


### PR DESCRIPTION
### Motivation
- Prevent the static document cache from temporarily exceeding `MAX_CACHE_SIZE` when multiple concurrent requests insert entries around the same time.

### Description
- Change eviction logic in `DocumentRetriever` to insert the fetched document into the static cache first and then evict in a loop until the cache size is within `MAX_CACHE_SIZE`.
- Replace the previous single-check pre-insert eviction with a robust post-insert `while` loop to handle race conditions where multiple inserts can briefly push the cache over the limit.
- Keep existing LRU-like behavior by refreshing insertion order on cache hits and deleting the oldest keys during eviction.

### Testing
- Ran the test suite with `yarn test` and all unit tests passed.
- Verified TypeScript compilation with `yarn build` and linting with `yarn lint`, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab7e0f9288327becdedf8acf9f789)